### PR TITLE
[ FIX ] 프로필 수정 시 nickname, email NULL 오류 수정

### DIFF
--- a/src/user/user.repository.js
+++ b/src/user/user.repository.js
@@ -18,12 +18,12 @@ export const updateUserProfile = async (userId, nickname, email, profileImage) =
   const values = [];
   const updates = [];
 
-  if (nickname !== undefined && nickname !== null) {
+  if (nickname !== undefined && nickname !== null && nickname !== "") {
     updates.push(`nickname = ?`);
     values.push(nickname);
   }
 
-  if (email !== undefined && email !== null) {
+  if (email !== undefined && email !== "") {
     updates.push(`email = ?`);
     values.push(email);
   }


### PR DESCRIPTION
## 📎 Issue 번호
* #76 

## 📄 작업 내용 요약
- [ ] 프로필 수정 API 닉네임, 이메일 중 하나만 입력 시 NULL로 변경되는 오류 수정

## ☁️ 기타 설명 사항

