### PR TITLE
fix: 최근 출발지 검색 API 에러 핸들러 수정

### DIFF
--- a/src/community/community.controller.js
+++ b/src/community/community.controller.js
@@ -119,14 +119,17 @@ export const get_local_search_controller = async(req, res) => {
     try{
         const get_key = await get_local_search_service(user_id);
 
-        if(get_key) {
+        if(get_key.length > 0) {
             res.status(StatusCodes.OK).json(get_key);
         } else {
-            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message: "최근 검색어 조회 중에 에러가 발생했습니다."});
+            res.status(StatusCodes.OK).json({
+                message: "최근 검색어가 없습니다.",
+                data: []
+            });
         }
     } catch (error) {
         console.error(error);
-        res.status(StatusCodes.NOT_FOUND).json({message : "해당 사용자의 최근 출발한 지역을 찾을 수 없습니다."});
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message : "최근 검색어 조회 중에 에러가 발생했습니다."});
     }
 }
 

--- a/src/community/community.service.js
+++ b/src/community/community.service.js
@@ -84,9 +84,6 @@ export const delete_post_service = async (post_id, user_id) => {
 export const get_local_search_service = async(user_id) => {
     const get_key = await get_local_search_repository(user_id);
     
-    if(Array.isArray(get_key) && get_key.length === 0) {
-        throw new Error("최근 검색어가 조회되지 않았습니다.");
-    }
     return get_key;
 }
 

--- a/swagger/community.swagger.yaml
+++ b/swagger/community.swagger.yaml
@@ -315,43 +315,49 @@ paths:
         - COMMUNITY
       responses:
         '200':
-          description: "최근 출발 지역 조회 성공"
+          description: "최근 출발 지역 조회 성공 (데이터가 있을 경우) / 최근 검색어가 없습니다. (빈 배열 반환)"
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    local_id:
-                      type: integer
-                      example: 1
-                    region_name:
-                      type: string
-                      example: "인천광역시"
-                    location_name:
-                      type: string
-                      example: "인천"   
-            example:
-              - local_id: 3
-                region_name: "인천광역시"
-                location_name: "인천"
-              - local_id: 25
-                region_name: "부산광역시"
-                location_name: "부산"
-              - local_id: 6
-                region_name: "경기도"
-                location_name: "용인"
-        '404':
-          description: "사용자가 없습니다."
-          content: 
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    example: "해당 사용자의 최근 출발한 지역을 찾을 수 없습니다."
+                oneOf: 
+                  - type: array
+                    items:
+                      type: object
+                      properties:
+                        local_id:
+                          type: integer
+                          example: 1
+                        region_name:
+                          type: string
+                          example: "인천광역시"
+                        location_name:
+                          type: string
+                          example: "인천"   
+                  - type: object
+                    properties:
+                      message: 
+                        type: string
+                        example: "최근 검색어가 없습니다."
+                      data:
+                        type: array
+                        items: {}
+              examples:
+                success:
+                  value:  
+                    - local_id: 3
+                      region_name: "인천광역시"
+                      location_name: "인천"
+                    - local_id: 25
+                      region_name: "부산광역시"
+                      location_name: "부산"
+                    - local_id: 6
+                      region_name: "경기도"
+                      location_name: "용인"
+                noData:
+                  value:
+                    message: "최근 검색어가 없습니다."
+                    data: []
+            
         '500':
           description: "서버 에러"
           content:


### PR DESCRIPTION

## 📎 Issue 번호
- #78 

## 📄 작업 내용 요약
- 최근 여행지가 없어도 빈 배열과 메세지, 200 OK로 출력
- swagger도 이에 맞춰서 수정

