### PR TITLE
refactor: 댓글 삭제 API 수정

### DIFF
--- a/src/community/community.controller.js
+++ b/src/community/community.controller.js
@@ -348,7 +348,13 @@ export const delete_comment_controller = async(req,res) => {
 
     } catch (error) {
         console.log(error);
-        res.status(StatusCodes.NOT_FOUND).json({message: "존재하지 않는 게시물, 댓글 입니다."});
+        if (error.message === "게시글 또는 댓글이 존재하지 않습니다.") {
+            res.status(StatusCodes.NOT_FOUND).json({ message: "존재하지 않는 게시물, 댓글입니다." });
+        } else if (error.message === "삭제 권한이 없습니다.") {
+            res.status(StatusCodes.FORBIDDEN).json({ message: "삭제할 권한이 없습니다." });
+        } else {
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: "댓글 삭제 중 에러가 발생했습니다." });
+        }
     }
 }
 

--- a/src/community/community.repository.js
+++ b/src/community/community.repository.js
@@ -427,6 +427,18 @@ export const create_comment_repository = async(post_id, user_id, data) => {
 
 // 댓글 삭제 
 export const delete_comment_respository = async(post_id, comment_id, user_id) => {
+    
+    const checkQuery = `SELECT user_id FROM Comment WHERE post_id = ? AND id = ?`;
+    const [rows] = await pool.execute(checkQuery, [post_id, comment_id]);
+
+    if (rows.length === 0) {
+        return null; 
+    }
+
+    if (rows[0].user_id !== user_id) {
+        return false;
+    }
+    
     const query = `
         DELETE FROM Comment
         WHERE post_id = ? AND id = ? AND user_id = ?;

--- a/src/community/community.service.js
+++ b/src/community/community.service.js
@@ -231,8 +231,11 @@ export const create_comment_service = async(post_id, user_id, data) => {
 export const delete_comment_service = async(post_id, comment_id, user_id) => {
     const delete_key = await delete_comment_respository(post_id, comment_id, user_id);
 
-    if(!delete_key){
-        throw new Error("댓글이 삭제되지 않았습니다.");
+    if (delete_key === null) {
+        throw new Error("게시글 또는 댓글이 존재하지 않습니다.");
+    }
+    if (!delete_key) {
+        throw new Error("삭제 권한이 없습니다.");
     }
 
     return delete_key;

--- a/swagger/community.swagger.yaml
+++ b/swagger/community.swagger.yaml
@@ -1076,7 +1076,18 @@ paths:
                     example: 8
                   message:
                     type: string
-                    example: "댓글이 성공적으로 삭제되었습니다." 
+                    example: "댓글이 성공적으로 삭제되었습니다."
+        '403':
+          description: "삭제할 권한이 없음"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "삭제할 권한이 없습니다."
+
         '404':
           description: "존재하지 않는 게시물 또는 댓글"
           content:


### PR DESCRIPTION

## 📎 Issue 번호
- #88 

## 📄 작업 내용 요약
- 댓글 작성자가 아닐 때 삭제를 시도할 경우 404 NOT FOUND 상태 코드를 사용하였으나, 403 FORBIDDEN 상태 코드로 변경함 

