### PR TITLE
refactor: 댓글 삭제 API 에러 핸들러 수정

### DIFF
--- a/src/community/community.controller.js
+++ b/src/community/community.controller.js
@@ -351,7 +351,7 @@ export const delete_comment_controller = async(req,res) => {
         if (error.message === "게시글 또는 댓글이 존재하지 않습니다.") {
             res.status(StatusCodes.NOT_FOUND).json({ message: "존재하지 않는 게시물, 댓글입니다." });
         } else if (error.message === "삭제 권한이 없습니다.") {
-            res.status(StatusCodes.FORBIDDEN).json({ message: "삭제할 권한이 없습니다." });
+            res.status(StatusCodes.ACCEPTED).json({ message: "삭제할 권한이 없습니다." });
         } else {
             res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: "댓글 삭제 중 에러가 발생했습니다." });
         }

--- a/swagger/community.swagger.yaml
+++ b/swagger/community.swagger.yaml
@@ -23,6 +23,9 @@ paths:
                     type: string
                     format: binary
                   description: 업로드할 이미지 파일 리스트
+              required:
+                - picture_url
+
       responses:
         '200':
           description: 이미지 업로드 성공
@@ -1117,7 +1120,7 @@ paths:
                   message:
                     type: string
                     example: "댓글이 성공적으로 삭제되었습니다."
-        '403':
+        '202':
           description: "삭제할 권한이 없음"
           content:
             application/json:


### PR DESCRIPTION

## 📎 Issue 번호
- #93 

## 📄 작업 내용 요약
- 댓글 삭제 API에서 다른 사용자의 댓글 삭제 시 204 상태 코드를 출력하도록 변경


