### PR TITLE
Feat: 게시글 작성 API 미션 추가

### DIFF
--- a/src/community/community.repository.js
+++ b/src/community/community.repository.js
@@ -35,7 +35,35 @@ export const create_post_repository = async(data, user_id) => {
 
     const [new_post] = await pool.execute(new_query, [post_id]);
 
-    return new_post[0];
+    const post_data = new_post[0];
+
+    if (post_data && post_data.picture_url) {
+        post_data.picture_url = JSON.parse(post_data.picture_url);
+    }
+
+    if (category_id === 2) {
+        const mission_query = `
+            INSERT INTO mission (title, imageUrl, content, point)
+            VALUES (?,?,?,0);
+        `;
+        await pool.execute(mission_query, [title, picture_url[0], content]);
+
+        const add_mission_query = `
+            SELECT * FROM mission WHERE title = ? AND content = ? ORDER BY id DESC LIMIT 1;
+        `;
+
+        const [mission] = await pool.execute(add_mission_query, [title, content]);
+        const mission_data = mission[0];
+
+        return {
+            post: post_data,
+            mission: mission_data
+        };
+    } else {
+        return {
+            post: post_data
+        };
+    }
 };
 
 

--- a/src/community/community.service.js
+++ b/src/community/community.service.js
@@ -62,9 +62,7 @@ export const create_post_service = async (data, user_id) => {
             throw new Error("postKey가 존재하지 않습니다.");
         }
 
-        const response_dto = create_post_response_dto(post_key);
-
-        return response_dto;
+        return post_key;
 
     } catch(error) {
         console.error("게시글 생성 서비스 에러: ", error);

--- a/swagger/community.swagger.yaml
+++ b/swagger/community.swagger.yaml
@@ -118,6 +118,7 @@ paths:
   /community/posts:
     post:
       summary: "즉흥여행 게시글 작성"
+      description: 게시글을 작성하고, 만약 게시글의 카테고리가 미션 제안(=2) 일 경우 미션을 생성함 
       tags:
         - COMMUNITY
       requestBody:
@@ -158,45 +159,143 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  post_id: 
-                    type: integer
-                    description: 게시물 ID
-                    example: 22
-                  user_nickname: 
-                    type: string
-                    description: 사용자 이름 
-                  category_name:
-                    type: string
-                    description: 카테고리 이름
-                    example: "현지 정보"
-                  location_name:
-                    type: string
-                    description: 지역 이름
-                    example: "제주"
-                  title:
-                    type: string
-                    description: 게시물 제목
-                    example: "이런건 어떤가요 ㅋㅋㅋ"
-                  content:
-                    type: string
-                    description: 게시물 본문
-                    example: "순천 안온해변에서 어쩌고"
-                  picture_url:
-                    type: array
-                    description: 이미지(최대 5개)
-                    example:
-                      - "https://example.com/uploads/image1.jpg"
-                      - "https://example.com/uploads/image2.jpg"
-                    items:
-                      type: string
-                      format: uri
-                  created_at:
-                    type: string
-                    format: date-time
-                    description: 생성 일시
-                    example: "2025-01-18T17:29:30.000Z"
+                oneOf:
+                  - type: object
+                    properties:
+                      post: 
+                        type: object
+                        properties:
+                          post_id: 
+                            type: integer
+                            description: 게시물 ID
+                            example: 22
+                          user_nickname: 
+                            type: string
+                            description: 사용자 이름 
+                          category_name:
+                            type: string
+                            description: 카테고리 이름
+                            example: "현지 정보"
+                          location_name:
+                            type: string
+                            description: 지역 이름
+                            example: "제주"
+                          title:
+                            type: string
+                            description: 게시물 제목
+                            example: "이런건 어떤가요 ㅋㅋㅋ"
+                          content:
+                            type: string
+                            description: 게시물 본문
+                            example: "순천 안온해변에서 어쩌고"
+                          picture_url:
+                            type: array
+                            description: 이미지(최대 5개)
+                            example:
+                              - "https://example.com/uploads/image1.jpg"
+                              - "https://example.com/uploads/image2.jpg"
+                            items:
+                              type: string
+                              format: uri
+                          created_at:
+                            type: string
+                            format: date-time
+                            description: 생성 일시
+                            example: "2025-01-18T17:29:30.000Z"
+                      mission:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: 미션 ID (카테고리가 미션 제안(2)일 경우에만 포함됨)
+                          title: 
+                            type: string
+                            description: 미션 제목
+                          imageUrl:
+                            type: string
+                            description: 미션 이미지 URL (맨 앞 1장) 
+                          content:
+                            type: string
+                            description: 미션 내용
+                          point:
+                            type: integer
+                            description: 미션 포인트 (기본값 = 0)
+                            default: 0
+                  - type: object
+                    properties:
+                    post: 
+                      type: object
+                      properties:
+                        post_id: 
+                          type: integer
+                          description: 게시물 ID
+                          example: 22
+                        user_nickname: 
+                          type: string
+                          description: 사용자 이름 
+                        category_name:
+                          type: string
+                          description: 카테고리 이름
+                          example: "현지 정보"
+                        location_name:
+                          type: string
+                          description: 지역 이름
+                          example: "제주"
+                        title:
+                          type: string
+                          description: 게시물 제목
+                          example: "이런건 어떤가요 ㅋㅋㅋ"
+                        content:
+                          type: string
+                          description: 게시물 본문
+                          example: "순천 안온해변에서 어쩌고"
+                        picture_url:
+                          type: array
+                          description: 이미지(최대 5개)
+                          example:
+                            - "https://example.com/uploads/image1.jpg"
+                            - "https://example.com/uploads/image2.jpg"
+                          items:
+                            type: string
+                            format: uri
+                        created_at:
+                          type: string
+                          format: date-time
+                          description: 생성 일시
+                          example: "2025-01-18T17:29:30.000Z"
+              examples:
+                missionAvailable(category_id = 2):
+                  value:  
+                    post: 
+                      post_id: 22
+                      user_nickname: "testuser"
+                      category_name: "미션 제안"
+                      location_name: "서울"
+                      title: "미션 제목"
+                      content: "미션 내용"
+                      picture_url:
+                        - "https://example.com/uploads/image1.jpg"                          
+                        - "https://example.com/uploads/image2.jpg"
+                    mission:
+                      id: 10
+                      title: "미션 제목"
+                      imageUrl: "https://example.com/uploads/mission_image.jpg"
+                      content: "미션 내용"
+                      point: 0
+                missionNotAvailable(category_id != 2):
+                  value:
+                    post: 
+                      post_id: 22
+                      user_nickname: "testuser"
+                      category_name: "즉흥 자랑"
+                      location_name: "서울"
+                      title: "게시물 제목"
+                      content: "게시물 내용"
+                      picture_url:
+                        - "https://example.com/uploads/image1.jpg"
+                        - "https://example.com/uploads/image2.jpg"
+                      created_at: "2025-01-18T17:29:30.000Z"
+                  
         "400":
           description: 잘못된 요청
           content:


### PR DESCRIPTION

## 📎 Issue 번호
- #92 

## 📄 작업 내용 요약
- User가 category_id가 2인(= 미션 제안) 글을 작성 시에 mission 테이블에 사용자가 작성한 글을 저장함 
- mission 테이블에 저장 시에만 저장된 결과를 응답으로 보여줌 
